### PR TITLE
Allow users to specify the full path to god

### DIFF
--- a/README.textile
+++ b/README.textile
@@ -127,6 +127,17 @@ san_juan.role :web, %w(nginx)
 </code>
 </pre>
 
+If you would like to specify the full path to your god executable you can specify the command with the god_command variable:
+
+<pre>
+<code>
+require 'san_juan'
+
+set :god_command, "/usr/local/bin/god"
+</code>
+</pre>
+
+
 h2. Author
 
 "Jesse Newland":http://jnewland.com/

--- a/lib/san_juan.rb
+++ b/lib/san_juan.rb
@@ -48,32 +48,32 @@ module SanJuan
       namespace role do
         desc "Start god"
         task :start, :roles => role do
-          sudo "god -c #{san_juan.configuration_path(current_path, role)}"
+          sudo "#{san_juan.god_command} -c #{san_juan.configuration_path(current_path, role)}"
         end
 
         desc "Start god interactively"
         task :start_interactive, :roles => role do
-          sudo "god -c #{san_juan.configuration_path(current_path, role)} -D"
+          sudo "#{san_juan.god_command} -c #{san_juan.configuration_path(current_path, role)} -D"
         end
 
         desc "Reload the god config file"
         task :reload, :roles => role do
-          sudo "god load #{san_juan.configuration_path(current_path, role)}"
+          sudo "#{san_juan.god_command} load #{san_juan.configuration_path(current_path, role)}"
         end
 
         desc "Quit god, but not the processes it's monitoring"
         task :quit, :roles => role do
-          sudo 'god quit'
+          sudo "#{san_juan.god_command} quit"
         end
 
         desc "Terminate god and all monitored processes"
         task :terminate, :roles => role do
-          sudo 'god terminate'
+          sudo "#{san_juan.god_command} terminate"
         end
 
         desc "Describe the status of the running tasks"
         task :status, :roles => role do
-          sudo 'god status'
+          sudo "#{san_juan.god_command} status"
         end
 
         watches.each do |watch|
@@ -81,7 +81,7 @@ module SanJuan
             %w(start restart stop unmonitor remove log).each do |command|
               desc "#{command.capitalize} #{watch}"
               task command, :roles => role do
-                sudo "god #{command} #{watch}"
+                sudo "#{san_juan.god_command} #{command} #{watch}"
               end
             end
           end
@@ -94,6 +94,10 @@ module SanJuan
 
   def configuration_path(current_path, role)
     fetch(:god_config_path, nil) || "#{current_path}/config/god/#{role}.god"
+  end
+  
+  def god_command
+    fetch(:god_command, nil) || "god"
   end
 
 end


### PR DESCRIPTION
I've update the receipt to specify the "god_command" in the Capistrano recipe so that if "god" is not within the sudo user's path, it can be executed. 

I've also updated the associated README
